### PR TITLE
fix link to Compendium in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Malazan Book of the Fallen Compendium
 👇 View the Compendium
 
-[Malazan Compendium by Atharva Shah](highnessatharva.github.io/Malazan-Compendium)
+[Malazan Compendium by Atharva Shah](https://highnessatharva.github.io/Malazan-Compendium)
 
 # About 
 


### PR DESCRIPTION
the readme's "view compendium" link pointed to [https://github.com/HighnessAtharva/Malazan-Compendium/blob/main/highnessatharva.github.io/Malazan-Compendium](https://github.com/HighnessAtharva/Malazan-Compendium/blob/main/highnessatharva.github.io/Malazan-Compendium) instead of the actual compendium